### PR TITLE
fix(TaskList): check for undefined tasks in filter pipe.

### DIFF
--- a/src/components/tasks/task-list/task-list-filter-pipe.spec.ts
+++ b/src/components/tasks/task-list/task-list-filter-pipe.spec.ts
@@ -40,4 +40,9 @@ describe('TaskListFilterPipe', () => {
   it('should return provided list if param `filterType` is not `active` or `completed`', () => {
     expect(pipe.transform(list, [''])).toBe(list);
   });
+
+  it('should return provided list if list is undefined and filter is provided', () => {
+    list = undefined;
+    expect(pipe.transform(list, ['active'])).toBe(list);
+  });
 });

--- a/src/components/tasks/task-list/task-list-filter-pipe.ts
+++ b/src/components/tasks/task-list/task-list-filter-pipe.ts
@@ -9,7 +9,7 @@ import { ITask } from '../../../core/task/task';
 
 export class TaskListFilterPipe implements PipeTransform {
   transform(list: ITask[], filterType?: string[]): ITask[] {
-    if (!filterType || !filterType.length) {
+    if (list === undefined || !filterType || !filterType.length) {
       return list;
     }
 


### PR DESCRIPTION
I noticed that if you try to refresh the page when there is a filter applied, it kills the filter pipe.  It's due to not receiving the list of tasks from Firebase yet.  I'm not 100% sure this is the correct fix, though.  It seems the filter should only be applied after the list of tasks have come back, but that might be a larger refactor?