### PR TITLE
refactor(TaskStore): minor updates

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -8,12 +8,12 @@ module.exports = function(config) {
       {pattern: 'node_modules/systemjs/dist/system.src.js', included: true, watched: true},
       {pattern: 'node_modules/angular2/bundles/angular2.js', included: true, watched: true},
       {pattern: 'node_modules/angular2/bundles/testing.js', included: true, watched: true},
+      {pattern: 'node_modules/immutable/dist/immutable.js', included: true, watched: true},
       {pattern: 'node_modules/mockfirebase/browser/mockfirebase.js', included: true, watched: true},
       {pattern: 'node_modules/sinon/pkg/sinon.js', included: true, watched: true},
       {pattern: 'karma.entry.js', included: true, watched: true},
 
       // paths loaded via module imports
-      {pattern: 'node_modules/immutable/**', included: false, watched: false},
       {pattern: 'target/**/*.js', included: false, watched: false},
 
       // paths loaded via Angular's component compiler

--- a/karma.entry.js
+++ b/karma.entry.js
@@ -23,6 +23,7 @@ System.config({
   },
 
   paths: {
+    'immutable': '/base/node_modules/immutable/dist/immutable.js',
     'firebase': '/base/target/utils/firebase-mock.js'
   }
 });

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "gulp-postcss": "~6.0.1",
     "gulp-sass": "~2.1.0",
     "gulp-sourcemaps": "~1.6.0",
-    "gulp-tslint": "~3.6.0",
+    "gulp-tslint": "~4.0.0",
     "gulp-typescript": "~2.9.2",
     "jasmine-core": "~2.3.4",
     "karma": "~0.13.15",
@@ -37,6 +37,7 @@
     "minx": "~0.4.14",
     "mockfirebase": "~0.12.0",
     "sinon": "~1.17.2",
+    "tslint": "~3.0.0",
     "typescript": "~1.6.2"
   }
 }

--- a/src/components/tasks/task-list/task-list.ts
+++ b/src/components/tasks/task-list/task-list.ts
@@ -5,6 +5,7 @@ import {
   View
 } from 'angular2/angular2';
 import { RouterLink, RouteParams } from 'angular2/router';
+import { List } from 'immutable';
 import { ReplaySubject } from '@reactivex/rxjs/dist/cjs/Rx';
 import { TaskItem } from '../task-item/task-item';
 import { TaskListFilterPipe } from './task-list-filter-pipe';
@@ -28,7 +29,7 @@ import { TaskListFilterPipe } from './task-list-filter-pipe';
 })
 
 export class TaskList {
-  @Input() tasks: ReplaySubject<any>;
+  @Input() tasks: ReplaySubject<List<any>>;
 
   filter: string;
 

--- a/src/core/task/task-store.ts
+++ b/src/core/task/task-store.ts
@@ -4,7 +4,7 @@ import { ITask } from './task';
 
 
 export class TaskStore {
-  tasks: ReplaySubject<any> = new ReplaySubject(1);
+  tasks: ReplaySubject<List<any>> = new ReplaySubject(1);
   private list: List<any> = List();
 
   constructor(ref: Firebase) {
@@ -14,12 +14,16 @@ export class TaskStore {
     ref.once('value', () => this.emit());
   }
 
-  emit(): void {
-    this.tasks.next(this.list);
+  get size(): number {
+    return this.list.size;
   }
 
   subscribe(next: (list: List<any>) => void): any {
     return this.tasks.subscribe(next);
+  }
+
+  private emit(): void {
+    this.tasks.next(this.list);
   }
 
   private created(snapshot: FirebaseDataSnapshot): void {


### PR DESCRIPTION
- Change ReplaySubject type from `any` to `List<any>`
- Add getter to return the number of tasks in store
- Make `emit()` a private member