### PR TITLE
chore(lock-node): locks node to 6.5 in package.json, circle.yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 6.4
+    version: 6.5
 
 dependencies:
   pre:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "private": true,
   "engines": {
-    "node": ">=5.11"
+    "node": ">=6.5"
   },
   "scripts": {
     "build": "cross-env NODE_ENV=production webpack --display-chunks --progress",


### PR DESCRIPTION
### Summary of Changes

- sets node version to `>= 6.5` (closes issue #97)